### PR TITLE
[syncd] Update log level for bulkSet api

### DIFF
--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -2071,7 +2071,7 @@ sai_status_t Syncd::processBulkOidSet(
 
     if (status == SAI_STATUS_NOT_IMPLEMENTED || status == SAI_STATUS_NOT_SUPPORTED)
     {
-        SWSS_LOG_ERROR("bulkSet api is not implemented or not supported, object_type = %s",
+        SWSS_LOG_WARN("bulkSet api is not implemented or not supported, object_type = %s",
                 sai_serialize_object_type(objectType).c_str());
     }
 


### PR DESCRIPTION
Log level should be warning instead of error, because functionality is fine. Latter code will use single set instead of bulk set, when syncd support bulk but sai doesn't support it.