### PR TITLE
Prevent invalid parameters in saiLoglevelNotify

### DIFF
--- a/meta/SaiSerialize.cpp
+++ b/meta/SaiSerialize.cpp
@@ -3017,6 +3017,12 @@ void sai_deserialize_enum(
 {
     SWSS_LOG_ENTER();
 
+    if (s.empty())
+    {
+        SWSS_LOG_ERROR("Empty string input for enum deserialization");
+        return;
+    }
+
     if (meta == NULL)
     {
         return sai_deserialize_number(s, value);

--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -1887,6 +1887,18 @@ sai_status_t VendorSai::logSet(
 {
     SWSS_LOG_ENTER();
 
+    if (api < SAI_API_UNSPECIFIED || api >= SAI_API_MAX)
+    {
+        SWSS_LOG_ERROR("Invalid api value: 0x%lx", api);
+        return SAI_STATUS_INVALID_PARAMETER;
+    }
+
+    if (log_level < SAI_LOG_LEVEL_DEBUG || log_level > SAI_LOG_LEVEL_CRITICAL)
+    {
+        SWSS_LOG_ERROR("Invalid log_level value: 0x%lx", log_level);
+        return SAI_STATUS_INVALID_PARAMETER;
+    }
+
     m_logLevelMap[api] = log_level;
 
     return m_globalApis.log_set(api, log_level);


### PR DESCRIPTION
Background is a crash in VendorSai::logSet when receiving invalid parameters from saiLoglevelNotify. The crash occurred when deserializing empty or invalid string values resulted in corrupted api and log_level values. Changes are adding input validation for api and log_level parameters.